### PR TITLE
feat(correction exo)

### DIFF
--- a/auteur
+++ b/auteur
@@ -1,1 +1,1 @@
-echo "dcharlat"."\n";
+dcharlat


### PR DESCRIPTION
le fichier auteur doit contenir dcharlat suivi d'un retour à la ligne.
En règle générale, on considère une bonne pratique de finir les fichiers par des retours à la ligne.

Pourquoi ?
- Si on concatène des fichiers la première ligne du deuxième fichier sera à la suite de la dernière ligne du premier fichier ... sur la même ligne, ce qui n'est pas propre.
- On peut formaliser en disant que du texte est une suite de lignes, et qu'une ligne est une suite de caractère terminé par un retour à la ligne. Si une ligne n'est pas terminé par une terminaison de ligne, est-ce vraiment une ligne ?
- Certains programmes interpretent le retour à la ligne sur l'entrée standard comme une fin d'instruction (le fait de taper entrée), en absence de retour à la ligne en fin de fichiers, ces programmes pourraient être dans un état d'attente (de la fin d'instruction), si on leur pipe le contenu d'un fichier sur l'entrée standard.